### PR TITLE
fix: Define explicit ctors for NullableFunction

### DIFF
--- a/src/ltl/Range/NullableFunction.h
+++ b/src/ltl/Range/NullableFunction.h
@@ -14,6 +14,12 @@ namespace ltl {
 
 template <typename F>
 struct NullableFunction {
+    constexpr NullableFunction() = default;
+    constexpr NullableFunction(F f) : m_function{std::move(f)} {}
+
+    constexpr NullableFunction(const NullableFunction &) = default;
+    constexpr NullableFunction(NullableFunction &&) = default;
+
     constexpr NullableFunction &operator=(NullableFunction f) {
         m_function.reset();
         if (f.m_function)


### PR DESCRIPTION
This is the fix for #9 I suggested. I didn't write any test for this since it is an issue with compiler warning and I was not sure if it would be wanted, but at least it pass the tests with the current configuration.